### PR TITLE
Allow failling silently if row insertion doesn't comply with table constraints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.wjoel</groupId>
   <artifactId>kafka-connect-psql-jsonb-sink</artifactId>
-  <version>0.2</version>
+  <version>0.3</version>
   <packaging>jar</packaging>
 
   <url>https://github.com/wjoel/kafka-connect-psql-jsonb-sink</url>

--- a/src/main/java/com/wjoel/kafka_connect_psql_jsonb_sink/PsqlJsonbSinkTask.java
+++ b/src/main/java/com/wjoel/kafka_connect_psql_jsonb_sink/PsqlJsonbSinkTask.java
@@ -61,7 +61,7 @@ public class PsqlJsonbSinkTask extends SinkTask {
                     "ALTER TABLE temp0 ALTER COLUMN " + valueColumn
                             + " TYPE json USING to_json(" + valueColumn + ")");
             String insertTempTableSql = "INSERT INTO " + table + " SELECT " + maybeKeyColumnComma
-                + valueColumn + "::jsonb FROM temp0";
+                + valueColumn + "::jsonb FROM temp0 ON CONFLICT DO NOTHING";
             log.info("Creating table using: " + insertTempTableSql);
             copyTempTable = connection.prepareStatement(insertTempTableSql);
             dropTempTable = connection.prepareStatement("DROP TABLE temp0");


### PR DESCRIPTION
After noticing many duplicates being inserted to the database, I bumped into this article:
https://github.com/confluentinc/kafka-connect-jdbc/issues/173
It suggests this change. With it, the 'no-duplicates-constrain' can be created directly on
the database - and this library can allow for proceeding if the insert fails.